### PR TITLE
Add filepath dependency and set Content-Type for static files

### DIFF
--- a/monocle.cabal
+++ b/monocle.cabal
@@ -142,6 +142,7 @@ library
                      , envparse                   < 1
                      , exceptions                 >= 0.10
                      , fakedata                   >= 1.0
+                     , filepath
                      , fast-logger
                      , foldl
                      , gerrit                     >= 0.1.6


### PR DESCRIPTION
This update includes the addition of the 'filepath' dependency in the cabal file and implements a function to set the correct Content-Type headers for static files based on their extensions in the Main.hs file.